### PR TITLE
Update README.md to fix customizing active-skin image logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ inlcude active skin css
 
 Change logo by setting the `$skinLogo` variable above active_skin import line in active_admin.css.scss
 
-    $skinLogo: url("admin_logo.png") no-repeat 0 0;
+    $skinLogo: image-url("admin_logo.png") no-repeat 0 0;
 
 You can even change basic colors of the theme by placing some other variables:
   


### PR DESCRIPTION
My custom logo was missing in staging/production environments when precompiling assets. I found the fix - use `image-url` instead of just `url` in the `$skinLogo` variable override.